### PR TITLE
Developing JuiceFS support as a federable posix backend

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -21,10 +21,11 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.1"
+appVersion: "3.3.7"
 
 dependencies:
   - name: jupyterhub
-    version: "2.0.1-0.dev.git.6105.hb969fa50"
+    version: "3.3.7"
     repository: https://jupyterhub.github.io/helm-chart/
+
 

--- a/README.md
+++ b/README.md
@@ -18,30 +18,26 @@ bastionAdminPublicKey: # Put here a public RSA key for accessing the bastion as 
                        # You may have one in your `$HOME/.ssh/id_rsa.pub`, 
                        # otherwise run `ssh-keygen` to generate
 
-# juicefsMetaUrl is the url to the metadata backend (redis or PostgreSQL)
-juicefsMetaUrl: <URL to a valid metadata backend>
 
-# juicefsBucket is the url to the bucket where to store jfs data
+# if you prefer disabling juicefs, issue juicefsEnabled: False instead of the following lines
 juicefsBucket: <URL to a valid S3 bucket>
-
-# juicefsAccessKey is the access key of the object storage
 juicefsAccessKey: <Access Key for the storage bucket>
-
-# juicefsSecretKey is the secret key of the object storage
 juicefsSecretKey: <Secret Key for the storage bucket>
+juicefsMetaAuthToken: # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
 
-jhubIamClientId: # Put here the id of a client on iam.cloud.infn.it
-jhubIamClientSecret: # Put here the secret of your client
-jhubCryptKey: # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
-jhubMetricApiKey:  # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
+
+jhubIamClientId:      # Put here the id of a client on iam.cloud.infn.it
+jhubIamClientSecret:  # Put here the secret of your client
+jhubCryptKey:         # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
+jhubMetricApiKey:     # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
 
 dashboardFlaskSecret: # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
 
 jupyterhub:
   proxy:
-    secretToken: # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
+    secretToken:      # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
 
   hub:
-    cookieSecret: # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
+    cookieSecret:     # Generate and copy here a deployment-unique token: `openssl rand -hex 32`
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ bastionAdminPublicKey: # Put here a public RSA key for accessing the bastion as 
                        # You may have one in your `$HOME/.ssh/id_rsa.pub`, 
                        # otherwise run `ssh-keygen` to generate
 
+# juicefsMetaUrl is the url to the metadata backend (redis or PostgreSQL)
+juicefsMetaUrl: <URL to a valid metadata backend>
+
+# juicefsBucket is the url to the bucket where to store jfs data
+juicefsBucket: <URL to a valid S3 bucket>
+
+# juicefsAccessKey is the access key of the object storage
+juicefsAccessKey: <Access Key for the storage bucket>
+
+# juicefsSecretKey is the secret key of the object storage
+juicefsSecretKey: <Secret Key for the storage bucket>
+
 jhubIamClientId: # Put here the id of a client on iam.cloud.infn.it
 jhubIamClientSecret: # Put here the secret of your client
 jhubCryptKey: # Generate and copy here a deployment-unique token: `openssl rand -hex 32`

--- a/templates/jhub/jhub-env.yaml
+++ b/templates/jhub/jhub-env.yaml
@@ -13,6 +13,8 @@ data:
     jupyterhubCryptKey: {{ required "Missing jhubCryptKey" .Values.jhubCryptKey }} 
     nfsServerAddress:  {{ required "Missing nfsServerAddress" .Values.nfsServerAddress }}
     nfsMountPoint: /nfs-shared
+    jfsMountPoint: /jfs
+    jfsPvcName: {{ .Values.juicefsPersistentVolumeClaimName }}
     jupyterStartTimeout: {{ .Values.jhubStartTimeout | quote }}
     startupScript: {{ .Values.jhubStartupScript | default "/envs/setup.sh" | quote }}
 

--- a/templates/jhub/redis.yaml
+++ b/templates/jhub/redis.yaml
@@ -1,0 +1,125 @@
+{{ if .Values.juicefsEnabled }}
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.juicefsMetaNamespace }}
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: {{ .Values.juicefsMetaNamespace }}
+data:
+  redis-config: |
+    requirepass {{ .Values.juicefsMetaAuthToken }}
+    
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: {{ .Values.juicefsMetaNamespace }}
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      name: redis
+      namespace: {{ .Values.juicefsMetaNamespace }}
+      labels:
+        app.kubernetes.io/name: redis
+        component: redis
+
+    spec:
+      containers:
+      - name: redis
+        image: {{ .Values.redisImage | default "redis:latest" }}
+        command:
+          - redis-server
+          - "/redis-master/redis.conf"
+        env:
+        - name: MASTER
+          value: "true"
+        ports:
+        - containerPort: 6379
+        resources:
+          requests:
+            cpu: "500m"
+            memory: 512Mi
+          limits:
+            cpu: "2"
+            memory: 2Gi
+
+        volumeMounts:
+        - mountPath: /redis-master-data
+          name: data
+        - mountPath: /redis-master
+          name: config
+      volumes:
+        - name: data
+          hostPath:
+            path: /user-data/redis
+            type: DirectoryOrCreate 
+        - name: config
+          configMap:
+            name: redis-config
+            items:
+            - key: redis-config
+              path: redis.conf
+
+      nodeSelector:
+        storage: nfsexport
+
+--- 
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juicefs-firewall
+  namespace: {{ .Values.juicefsMetaNamespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+
+  policyTypes:
+  - Ingress
+
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 10.0.0.0/8
+    {{ range .Values.juicefsMetaTrustedCIDRs }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{ end }}
+    ports:
+    - protocol: TCP
+      port: 6379
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: jfs-redis
+  namespace: {{ .Values.juicefsMetaNamespace }}
+
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      nodePort: {{ .Values.juicefsMetaPort | default 30379 }} 
+    
+{{ end }}

--- a/templates/juicefs/persistency.yaml
+++ b/templates/juicefs/persistency.yaml
@@ -1,0 +1,68 @@
+{{ if .Values.juicefsEnabled }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: juicefs-secret
+type: Opaque
+stringData:
+  name: {{ .Values.juicefsFilesystemName | default "jfs" }}
+  metaurl: {{ .Values.juicefsMetaUrl }} 
+  storage: s3
+  bucket: {{ .Values.juicefsBucket }}
+  access-key: {{ .Values.juicefsAccessKey }}
+  secret-key: {{ .Values.juicefsSecretKey }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.juicefsPersistentVolumeName | default "juicefs-pv" }}
+  labels:
+    juicefs-name: {{ .Release.Name }}
+spec:
+  capacity:
+    storage: {{ .Values.juicefsStorage | default "256Gi" }}
+
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    # A CSIDriver named csi.juicefs.com is created during installation
+    driver: csi.juicefs.com
+    # volumeHandle needs to be unique within the cluster, simply using the PV name is recommended
+    volumeHandle: {{ .Values.juicefsPersistentVolumeName | default "juicefs-pv" }}
+    fsType: juicefs
+    # Reference the volume credentials (Secret) created in previous step
+    # If you need to use different credentials, or even use different JuiceFS volumes, you'll need to create different volume credentials
+    nodePublishSecretRef:
+      name: juicefs-secret
+      namespace: default
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.juicefsPersistentVolumeClaimName | default "juicefs" }}
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Filesystem
+  # Must use an empty string as storageClassName
+  # Meaning that this PV will not use any StorageClass, instead will use the PV specified by selector
+  storageClassName: ""
+  # For now, JuiceFS CSI Driver doesn't support setting storage capacity for static PV. Fill in any valid string that's lower than the PV capacity.
+  resources:
+    requests:
+      storage: "1Mi"   
+  selector:
+    matchLabels:
+      juicefs-name: {{ .Release.Name }}
+
+
+{{ end }}
+

--- a/templates/juicefs/persistency.yaml
+++ b/templates/juicefs/persistency.yaml
@@ -7,7 +7,7 @@ metadata:
 type: Opaque
 stringData:
   name: {{ .Values.juicefsFilesystemName | default "jfs" }}
-  metaurl: {{ .Values.juicefsMetaUrl }} 
+  metaurl: "redis://:{{- .Values.juicefsMetaAuthToken -}}@{{- .Values.hostname -}}:{{- .Values.juicefsMetaPort }}"
   storage: s3
   bucket: {{ .Values.juicefsBucket }}
   access-key: {{ .Values.juicefsAccessKey }}
@@ -63,6 +63,58 @@ spec:
     matchLabels:
       juicefs-name: {{ .Release.Name }}
 
+
+{{ else }} 
+
+################################################################################
+# if the pvc is not define, the hub refuses to start. 
+# To enable running the platform without juicefs, we mock it with nfs.
+#
+#apiVersion: storage.k8s.io/v1
+#kind: StorageClass
+#metadata: 
+#  name: fake-jfs
+#
+#---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: fake-juicefs
+  labels:
+    juicefs-name: {{ .Release.Name }}
+spec:
+  capacity:
+    storage: 2Mi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: fake-jfs
+  nfs:
+    server: "10.43.0.2"
+    path: "/"
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.juicefsPersistentVolumeClaimName | default "juicefs" }}
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Filesystem
+  # Must use an empty string as storageClassName
+  # Meaning that this PV will not use any StorageClass, instead will use the PV specified by selector
+  storageClassName: "fake-jfs"
+  resources:
+    requests:
+      storage: "1Mi"   
+  selector:
+    matchLabels:
+      juicefs-name: {{ .Release.Name }}
 
 {{ end }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -88,9 +88,6 @@ nfsMetricsMonitoringSubPaths:
 #   jupyterhub.hub.extraVolumeMounts
 juicefsEnabled: True
 
-# juicefsMetaUrl is the url to the metadata backend (redis or PostgreSQL)
-juicefsMetaUrl: 
-
 # juicefsBucket is the url to the bucket where to store jfs data
 juicefsBucket: 
 
@@ -112,9 +109,19 @@ juicefsPersistentVolumeClaimName: juicefs
 # juicefsStorage is the size of the allocated storage
 juicefsStorage: 256Gi
 
+# juicefsMetaNamespace is the namespace where redis (or the meta engine) is installed
+juicefsMetaNamespace: juicefs-meta
 
+# juicefsMetaAuthToken is the token for accessing Redis
+juicefsMetaAuthToken: 
 
+# juicefsMetaPort is the NodePort to access redis from remote nodes
+juicefsMetaPort: 30379
 
+# juicefsMetaTrustedIPs is the list of IPs from which Redis accepts connections 
+juicefsMetaTrustedCIDRs: 
+ - 131.154.99.38/32  # Cloud@CNAF
+  
 
 ################################################################################
 ## Cern Virtual-Machine FileSystem (cvmfs)

--- a/values.yaml
+++ b/values.yaml
@@ -75,6 +75,46 @@ nfsMetricsMonitoringPaths:
 # nfsMetricsMonitoringSubPaths list paths for which monitoring each subdir separately
 nfsMetricsMonitoringSubPaths:
   - NFS
+  
+
+################################################################################
+## JuiceFS. https://juicefs.com/docs/csi/getting_started
+## -----------------------------------------------------
+
+# juicefsEnabled enables the JuiceFS configuration (default: True).
+# !!! WARNING !!!
+# If disabling juicefs, also remove jfs volume and volumeMouns from jupyterhub:
+#   jupyterhub.hub.extraVolumes
+#   jupyterhub.hub.extraVolumeMounts
+juicefsEnabled: True
+
+# juicefsMetaUrl is the url to the metadata backend (redis or PostgreSQL)
+juicefsMetaUrl: 
+
+# juicefsBucket is the url to the bucket where to store jfs data
+juicefsBucket: 
+
+# juicefsAccessKey is the access key of the object storage
+juicefsAccessKey: 
+
+# juicefsSecretKey is the secret key of the object storage
+juicefsSecretKey: 
+
+# juicefsPersistentVolumeName is the name of the pv created for JuiceFS
+juicefsPersistentVolumeName: juicefs-pv
+
+# juicefsPersistentVolumeClaimName is the name of the pvc to share JuiceFS
+# !!! WARNING !!!
+# If renaming the pvc, modify consistently the volume mounted in the hub
+#   jupyterhub.hub.extraVolumes
+juicefsPersistentVolumeClaimName: juicefs
+
+# juicefsStorage is the size of the allocated storage
+juicefsStorage: 256Gi
+
+
+
+
 
 ################################################################################
 ## Cern Virtual-Machine FileSystem (cvmfs)
@@ -444,13 +484,19 @@ jupyterhub:
           server: "10.43.0.2"
           path: "/"
 
+      - name: jfs
+        persistentVolumeClaim: 
+          claimName: juicefs
+
     extraVolumeMounts:
       - name: jhub-config
         mountPath: /usr/local/etc/jupyterhub/jupyterhub_config.d/
 
       - name: shared
         mountPath: /nfs-shared
- 
+
+      - name: jfs
+        mountPath: /jfs
 
     extraEnv:
       OAUTH_CALLBACK_URL: 
@@ -512,6 +558,19 @@ jupyterhub:
           configMapKeyRef:
             name: jhub-env
             key: nfsMountPoint
+
+      JFS_MOUNT_POINT:
+        valueFrom:
+          configMapKeyRef:
+            name: jhub-env
+            key: jfsMountPoint
+
+      JFS_PVC_NAME:
+        valueFrom:
+          configMapKeyRef:
+            name: jhub-env
+            key: jfsPvcName
+
 
       START_TIMEOUT:
         valueFrom: 


### PR DESCRIPTION
JuiceFS is a distributed almost-POSIX-compliant filesystem designed to decouple metadata and data in Cloud environment.
https://juicefs.com/docs/csi/getting_started

In this development we setup a JuiceFS to provide a storage solution parallel (for the moment not competitive) to NFS.

The main purposes are:
 * Provide a testbed to evaluate JuiceFS as a long-term replacement for NFS
 * Provide a solution to extend the storage beyond NFS limits
 * Study the feasibility of distributing JuiceFS through multiple sites

What remains to be done before merging:
 - [x] include redis deployment with minimal security in the chart 
 - [ ] include juicefs helm chart among the helm dependencies. CANNOT BE DONE.
 - [x] ensure juicefs can be easily disabled when installing the helm chart
 - [x] enable project directories in juicefs
